### PR TITLE
add base dispatch workflow

### DIFF
--- a/.github/workflows/upgrade-mint-dependencies.yml
+++ b/.github/workflows/upgrade-mint-dependencies.yml
@@ -1,0 +1,12 @@
+name: Upgrade Mint Dependencies
+
+on:
+  repository_dispatch:
+    types: [upgrade-mint-dependencies]
+
+jobs:
+  upgrade-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo Workflow executed!


### PR DESCRIPTION
## Summary

Add a simple workflow that can be triggered by API call. This is just a basic "hello world" workflow to test invoking the workflow from a different repository

## Test Plan

- [ ] Call `https://api.github.com/repos/mintlify/mintlify.com/dispatches` with appropriate headers and body (see [here](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event))
- [ ] Ensure workflow runs
