### PR TITLE
updated blog default slug, updated menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -24,9 +24,8 @@ export const navigation = [
     href: '/pricing',
   },
   {
-    name: 'Blogs',
-    href: '/blogs',
-    hideInHeaderDeskop: true,
+    name: 'Blog',
+    href: '/blog',
   },
   {
     name: 'Community',
@@ -38,11 +37,14 @@ export const navigation = [
     name: 'Careers',
     href: '/careers',
     hideInHeaderMobile: true,
+    hideInHeaderDeskop: true,
   },
   {
     name: 'Writer',
     href: '/writer',
     hideInFooter: true,
+    hideInHeaderDeskop: true,
+    hideInHeaderMobile: true,
   },
   {
     name: 'Status',

--- a/src/lib/getAllArticles.js
+++ b/src/lib/getAllArticles.js
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 async function importArticle(articleFilename) {
   let { meta, default: component } = await import(
-    `../pages/blogs/${articleFilename}`
+    `../pages/blog/${articleFilename}`
   )
   return {
     slug: articleFilename.replace(/(\/index)?\.mdx$/, ''),
@@ -14,7 +14,7 @@ async function importArticle(articleFilename) {
 
 export async function getAllArticles() {
   let articleFilenames = await glob(['*.mdx', '*/index.mdx'], {
-    cwd: path.join(process.cwd(), 'src/pages/blogs'),
+    cwd: path.join(process.cwd(), 'src/pages/blog'),
   })
 
   let articles = await Promise.all(articleFilenames.map(importArticle))

--- a/src/pages/blog/index.jsx
+++ b/src/pages/blog/index.jsx
@@ -11,7 +11,7 @@ function Article({ article }) {
     <Card>
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <article className="mb-16 max-w-lg cursor-pointer overflow-hidden rounded-lg transition-colors duration-200">
-          <a href={`/blogs/${article.slug}`}>
+          <a href={`/blog/${article.slug}`}>
             <div className="relative flex w-full justify-center">
               <Image
                 src={article.imageUrl}
@@ -54,14 +54,14 @@ export default function ArticlesIndex({ articles }) {
   return (
     <>
       <Head>
-        <title>Blogs - Beautiful documentation that converts users</title>
+        <title>Blog - Beautiful documentation that converts users</title>
         <meta
           name="Blogs"
           content="Build the documentation you've always wanted. Beautiful out of the box, easy to maintain, and optimized for user engagement."
         />
       </Head>
       <SimpleLayout
-        title="Blogs"
+        title="Blog"
         intro="Mintlify Chronicles: Navigating the World of Technical Documentation"
       >
         <div>

--- a/src/pages/blog/well-crafted-api-documentation-equals-product-success/index.mdx
+++ b/src/pages/blog/well-crafted-api-documentation-equals-product-success/index.mdx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 
 export const meta = {
   author: 'One Chowdhury',
-  date: '2023-06-19',
+  date: '2023-05-19',
   title: 'Well-crafted API documentation = Product success',
   description:
     'As software and digital products continue to evolve and advance, the emphasis on comprehensive and user-friendly API documentation has never been greater. Properly documented APIs offer a plethora of benefits, from increased productivity to improved developer experience. ',


### PR DESCRIPTION
## Summary
- Updated blog slug to _mintlify.com/blog/example-blog_ (Basically using **blog** instead of *blogs* in URL)
- Removed **Writer** from both header and footer menu
- Added blog in header menu and removed career (career is now only in footer menu)
- Fixed blog publishing date (it was in the future before)

## Screenshot
<img width="1372" alt="Screen Shot 2023-05-24 at 12 38 16 PM" src="https://github.com/mintlify/mintlify.com/assets/50631904/ec4a670a-ffa3-4f8a-bed6-827666c78949">

## Test

- [ ] If code looks sound
- [ ] all links are working 