### PR TITLE
updated pricing page for ChatGPT copywriting

### DIFF
--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -39,7 +39,7 @@ const plans = [
       'The Free plan plus:',
       'Unlimited editors',
       'Analytics and conversion insights',
-      'ChatGPT for your docs',
+      'ChatGPT for docs',
       'Custom subpaths /docs',
       'White-glove migrations',
       'Prioritized customer support',


### PR DESCRIPTION
## Summary 

Updated GPT-Search copywriting for the pricing page on startup plan. 

`ChatGPT for docs`

## Screenshot

![Screen Shot 2023-06-30 at 4 42 47 PM](https://github.com/mintlify/mintlify.com/assets/50631904/b53f22b2-20b6-42cb-b47c-907fe9921e07)

## Test plan
- code looks sound
